### PR TITLE
Add a script to generate difference between two multi-file latex projects

### DIFF
--- a/scripts/generate_diff.sh
+++ b/scripts/generate_diff.sh
@@ -1,5 +1,17 @@
 #!/use/bin/env bash
 
+# This shell script can generate the difference between two multi-file latex projects
+# It contains two steps:
+# 1. use 'latexpand' to merge multi-file latex projects into single latex files
+# 2. use 'latexdiff' to generate the difference between the two single latex files
+
+# Note:
+# 1. To show the difference of figures, the new latex project should include a new
+# figure file instead of replacing the original one. Also, the original figure file
+# should not be deleted in the new latex project.
+# 2. Showing the difference of tables is not well supported as decribed in the
+# following link: https://github.com/ftilmann/latexdiff/issues/5
+
 set -o nounset
 set -o pipefail
 set -o xtrace

--- a/scripts/generate_diff.sh
+++ b/scripts/generate_diff.sh
@@ -1,0 +1,35 @@
+#! /bin/bash
+
+set -o nounset
+set -o pipefail
+set -o xtrace
+set -o errexit
+
+if [[ "$#" != 2 ]] ; then
+    echo "Usage: $0 <old main tex file> <new main tex file>"
+    exit
+fi
+
+readonly TMP=$(mktemp -d)
+
+readonly OLD_MAIN_TEX_FILE=$1
+readonly NEW_MAIN_TEX_FILE=$2
+readonly OLD_MAIN_TEX_NAME=$(basename "${OLD_MAIN_TEX_FILE}")
+readonly NEW_MAIN_TEX_NAME=$(basename "${NEW_MAIN_TEX_FILE}")
+readonly OLD_MAIN_DIR=$(dirname "${OLD_MAIN_TEX_FILE}")
+readonly NEW_MAIN_DIR=$(dirname "${NEW_MAIN_TEX_FILE}")
+
+# merge multi-file latex project into one file with 'latexpand'
+pushd "${OLD_MAIN_DIR}"
+latexpand "${OLD_MAIN_TEX_NAME}" -o "${TMP}/old_artical.tex"
+popd
+
+pushd "${NEW_MAIN_DIR}"
+latexpand "${NEW_MAIN_TEX_NAME}" -o "${TMP}/new_artical.tex"
+popd
+
+latexdiff "${TMP}/old_artical.tex" "${TMP}/new_artical.tex" > "${NEW_MAIN_DIR}/tmp_diff_main.tex"
+
+pdflatex -synctex=1 -interaction=nonstopmode "${NEW_MAIN_DIR}/tmp_diff_main.tex"
+
+rm -rf "${TMP}"

--- a/scripts/generate_diff.sh
+++ b/scripts/generate_diff.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/use/bin/env bash
 
 set -o nounset
 set -o pipefail
@@ -12,25 +12,28 @@ fi
 
 readonly TMP=$(mktemp -d)
 
+trap "rm -rf ${TMP}" EXIT
+
 readonly OLD_MAIN_TEX_FILE=$1
 readonly NEW_MAIN_TEX_FILE=$2
 readonly OLD_MAIN_TEX_NAME=$(basename "${OLD_MAIN_TEX_FILE}")
 readonly NEW_MAIN_TEX_NAME=$(basename "${NEW_MAIN_TEX_FILE}")
 readonly OLD_MAIN_DIR=$(dirname "${OLD_MAIN_TEX_FILE}")
 readonly NEW_MAIN_DIR=$(dirname "${NEW_MAIN_TEX_FILE}")
+readonly OUTPUT_PATH="${NEW_MAIN_DIR}/tmp_diff_main.tex"
+
+readonly OLD_TMP_TEX_FILE="${TMP}/old_artical.tex"
+readonly NEW_TMP_TEX_FILE="${TMP}/new_artical.tex"
 
 # merge multi-file latex project into one file with 'latexpand'
 pushd "${OLD_MAIN_DIR}"
-latexpand "${OLD_MAIN_TEX_NAME}" -o "${TMP}/old_artical.tex"
+latexpand "${OLD_MAIN_TEX_NAME}" -o "${OLD_TMP_TEX_FILE}"
 popd
 
 pushd "${NEW_MAIN_DIR}"
-latexpand "${NEW_MAIN_TEX_NAME}" -o "${TMP}/new_artical.tex"
+latexpand "${NEW_MAIN_TEX_NAME}" -o "${NEW_TMP_TEX_FILE}"
 popd
 
-latexdiff "${TMP}/old_artical.tex" "${TMP}/new_artical.tex" > "${NEW_MAIN_DIR}/tmp_diff_main.tex"
+latexdiff "${OLD_TMP_TEX_FILE}" "${NEW_TMP_TEX_FILE}" > "${OUTPUT_PATH}"
 
-pdflatex -synctex=1 -interaction=nonstopmode "${NEW_MAIN_DIR}/tmp_diff_main.tex"
-
-rm -rf "${TMP}"
-
+pdflatex -synctex=1 -interaction=nonstopmode "${OUTPUT_PATH}"

--- a/scripts/generate_diff.sh
+++ b/scripts/generate_diff.sh
@@ -33,3 +33,4 @@ latexdiff "${TMP}/old_artical.tex" "${TMP}/new_artical.tex" > "${NEW_MAIN_DIR}/t
 pdflatex -synctex=1 -interaction=nonstopmode "${NEW_MAIN_DIR}/tmp_diff_main.tex"
 
 rm -rf "${TMP}"
+


### PR DESCRIPTION
oopsla asked to use latexdiff to show the difference between the revised version and the original version:
> Also submit a document that shows the changes you have made relative to the original submission, using latexdiff or a similar tool.
So I wrote this script, which might also be useful to others.
The script contains two steps:
- use 'latexpand' to merge a multi-file latex project into a single latex file
- use 'latexdiff' to generate the difference