### PR TITLE
remove natbib package

### DIFF
--- a/macro/pluverse-preamble.tex
+++ b/macro/pluverse-preamble.tex
@@ -18,7 +18,6 @@
 \usepackage{listings}
 \usepackage{multicol}
 \usepackage{multirow}
-\usepackage{natbib}
 \usepackage{subcaption}
 \usepackage{url}
 \usepackage{xspace}

--- a/macro/pluverse-preamble.tex
+++ b/macro/pluverse-preamble.tex
@@ -18,6 +18,9 @@
 \usepackage{listings}
 \usepackage{multicol}
 \usepackage{multirow}
+% The following package (natbib) will lead to conflict issue in IEEE template (i.e., conflict with cite package).
+% ACM template handles citations automatically, and does not recommend explicitly import natbib.
+% \usepackage{natbib}
 \usepackage{subcaption}
 \usepackage{url}
 \usepackage{xspace}


### PR DESCRIPTION
Remove usepackage natbib.

Using this package in IEEE template causes a conflict issue.
This does not affect ACM template, which handles citations automatically。